### PR TITLE
fix: Improve pygerber dependency specifications

### DIFF
--- a/.github/actions/setup-padne/action.yml
+++ b/.github/actions/setup-padne/action.yml
@@ -16,11 +16,6 @@ runs:
         sudo apt-get update
         sudo apt-get install -y --no-install-recommends kicad
 
-    - name: Install pygerber from git
-      shell: bash
-      run: |
-        pip3 install --break-system-packages --user git+https://github.com/Argmaster/pygerber
-
     - name: Build C++ part of the repository, install the package
       shell: bash
       run: |

--- a/README.md
+++ b/README.md
@@ -47,8 +47,6 @@ This is ideal if you want to hack on padne itself or are looking for a more ligh
 sudo apt update
 sudo apt upgrade
 sudo apt install python3-full python3-dev python3-pip git libegl1 libegl1-mesa-dev libmpfr-dev libgmp-dev libboost-dev kicad
-# Feel free to do this in a virtual environment if you do not want to install pygerber or padne globally
-pip3 install --user git+https://github.com/Argmaster/pygerber
 pip3 install --user -e .[test] -v
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ classifiers = [
 dependencies = [
     "lxml>=5.0.0",
     "numpy>=2.0.0",
-    "pygerber>=2.4.3",
+    "pygerber @ git+https://github.com/Argmaster/pygerber.git@main",
     "PySide6>=6.8.0",
     "PyOpenGL>=3.0.0",
     "scipy>=1.15.0",


### PR DESCRIPTION
No longer requires manual install, will pull from github automatically